### PR TITLE
Fix course listing in carga horaria

### DIFF
--- a/app/vicerrector/carga-horaria/page.tsx
+++ b/app/vicerrector/carga-horaria/page.tsx
@@ -159,7 +159,9 @@ export default function CargaHorariaPage() {
         .select('*')
         .eq('activo', true)
         .eq('periodo_id', periodoData.id)
-        .order('subnivel, curso, paralelo')
+        .order('subnivel', { ascending: true })
+        .order('curso', { ascending: true })
+        .order('paralelo', { ascending: true })
 
       setCursos(cursosData || [])
 

--- a/app/vicerrector/cursos/page.tsx
+++ b/app/vicerrector/cursos/page.tsx
@@ -85,7 +85,9 @@ export default function CursosPage() {
       const { data: cursosData, error: cursosError } = await supabase
         .from('cursos')
         .select('*')
-        .order('subnivel, curso, paralelo')
+        .order('subnivel', { ascending: true })
+        .order('curso', { ascending: true })
+        .order('paralelo', { ascending: true })
 
       if (cursosError) throw cursosError
       setCursos(cursosData || [])


### PR DESCRIPTION
## Summary
- fix ordering when loading courses in dashboard and course management

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869f8264bf08328809507ad78acaaf1