### PR TITLE
Fix course loading in carga-horaria

### DIFF
--- a/app/vicerrector/carga-horaria/page.tsx
+++ b/app/vicerrector/carga-horaria/page.tsx
@@ -158,7 +158,7 @@ export default function CargaHorariaPage() {
         .from('cursos')
         .select('*')
         .eq('activo', true)
-        .eq('periodo_id', periodoData.id)
+        // Mostrar todos los cursos disponibles
         .order('subnivel', { ascending: true })
         .order('curso', { ascending: true })
         .order('paralelo', { ascending: true })


### PR DESCRIPTION
## Summary
- remove period filter when listing courses in `carga-horaria`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a008c276883288ec139fd42f9b944