### PR TITLE
Fix course loading in carga-horaria

### DIFF
--- a/app/vicerrector/carga-horaria/page.tsx
+++ b/app/vicerrector/carga-horaria/page.tsx
@@ -158,7 +158,7 @@ export default function CargaHorariaPage() {
         .from('cursos')
         .select('*')
         .eq('activo', true)
-        .eq('periodo_id', periodoData.id)
+        // Mostrar todos los cursos disponibles
         .order('subnivel', { ascending: true })
         .order('curso', { ascending: true })
         .order('paralelo', { ascending: true })
@@ -658,6 +658,49 @@ export default function CargaHorariaPage() {
                 </button>
               </div>
             </form>
+
+            {/* Relaciones existentes */}
+            {cursoAsignaturas.length > 0 ? (
+              <div className="mt-8 overflow-x-auto">
+                <h3 className="text-lg font-semibold mb-4">
+                  Relaciones Curso-Asignatura
+                </h3>
+                <table className="min-w-full divide-y divide-gray-200 text-sm">
+                  <thead>
+                    <tr>
+                      <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                        Curso
+                      </th>
+                      <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                        Asignatura
+                      </th>
+                      <th className="px-4 py-2 text-left font-medium text-gray-500 uppercase">
+                        Horas/Sem
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200">
+                    {cursoAsignaturas.map((relacion) => (
+                      <tr key={relacion.id}>
+                        <td className="px-4 py-2">
+                          {relacion.cursos?.curso} {relacion.cursos?.paralelo}
+                        </td>
+                        <td className="px-4 py-2">
+                          {relacion.asignaturas?.nombre}
+                        </td>
+                        <td className="px-4 py-2 text-center">
+                          {relacion.horas_semanales}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="mt-8 text-sm text-gray-500 text-center">
+                No hay relaciones configuradas
+              </p>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- remove period filter when listing courses in `carga-horaria`
- display existing course/subject relations inside configuration modal

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a008c276883288ec139fd42f9b944