### PR TITLE
Fix Supabase admin key lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ pnpm dev
 bun dev
 ```
 
+### Environment Variables
+
+Create a `.env.local` file and include your Supabase credentials:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=<your-project-url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,7 +1,8 @@
 import { createClient } from '@supabase/supabase-js'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY!
+const supabaseServiceKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY!
 
 export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey, {
   auth: {


### PR DESCRIPTION
## Summary
- handle either `SUPABASE_SERVICE_ROLE_KEY` or `SUPABASE_SERVICE_KEY`
- document required environment variables for running locally

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b293730348328b9c7c8097ad70d16