### PR TITLE
Fix database insertion fields

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -83,13 +83,12 @@ export async function POST(request: NextRequest) {
 
     // Crear registro en tabla usuarios
     const nombre_completo = `${apellidos} ${nombres}`.trim()
-    
+
     const { error: dbError } = await supabaseAdmin
       .from('usuarios')
       .insert({
         id: authData.user.id,
         correo: email,
-        nombre_completo,
         apellidos,
         nombres,
         cedula: cedula || null,

--- a/app/test-connection/page.tsx
+++ b/app/test-connection/page.tsx
@@ -42,12 +42,17 @@ export default function TestConnection() {
           users: []
         })
       } else {
+        const processed = (data || []).map((u: any) => ({
+          ...u,
+          nombre_completo: `${u.apellidos ?? ''} ${u.nombres ?? ''}`.trim(),
+        }))
+
         setStatus({
           loading: false,
           connected: true,
           error: null,
-          users: data || [],
-          supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL
+          users: processed,
+          supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
         })
       }
 

--- a/app/vicerrector/carga-horaria/page.tsx
+++ b/app/vicerrector/carga-horaria/page.tsx
@@ -134,8 +134,11 @@ export default function CargaHorariaPage() {
 
           const total_horas = cargas.reduce((sum, c) => sum + c.horas_semanales, 0)
 
+          const nombre_completo = `${docente.apellidos ?? ''} ${docente.nombres ?? ''}`.trim()
+
           return {
             ...docente,
+            nombre_completo,
             cargas: cargas.filter(c => c.curso_asignatura.id),
             total_horas
           }

--- a/app/vicerrector/docentes/page.tsx
+++ b/app/vicerrector/docentes/page.tsx
@@ -58,7 +58,13 @@ export default function DocentesPage() {
         .order('apellidos')
 
       if (error) throw error
-      setDocentes(data || [])
+
+      const processed = (data || []).map((d) => ({
+        ...d,
+        nombre_completo: `${d.apellidos ?? ''} ${d.nombres ?? ''}`.trim()
+      }))
+
+      setDocentes(processed)
     } catch (error) {
       console.error('Error:', error)
       toast.error('Error al cargar docentes')
@@ -74,8 +80,6 @@ export default function DocentesPage() {
     try {
       if (editingDocente) {
         // Actualizar docente existente
-        const nombre_completo = `${formData.apellidos} ${formData.nombres}`.trim()
-        
         const { error } = await supabase
           .from('usuarios')
           .update({
@@ -83,7 +87,6 @@ export default function DocentesPage() {
             cedula: formData.cedula,
             apellidos: formData.apellidos,
             nombres: formData.nombres,
-            nombre_completo,
             area: formData.area,
             titulo: formData.titulo
           })

--- a/app/vicerrector/documentos/page.tsx
+++ b/app/vicerrector/documentos/page.tsx
@@ -38,9 +38,20 @@ export default function RevisarDocumentosPage() {
     try {
       const { data } = await supabase
         .from('documentos')
-        .select(`*, docentes:usuarios (nombre_completo), tipos_documento (nombre)`)
+        .select(`*, docentes:usuarios (apellidos, nombres), tipos_documento (nombre)`)
         .order('fecha_subida', { ascending: false })
-      setDocumentos(data || [])
+
+      const processed = (data || []).map((doc: any) => ({
+        ...doc,
+        docentes: doc.docentes
+          ? {
+              ...doc.docentes,
+              nombre_completo: `${doc.docentes.apellidos ?? ''} ${doc.docentes.nombres ?? ''}`.trim(),
+            }
+          : null,
+      }))
+
+      setDocumentos(processed)
     } catch (error) {
       console.error('Error loading documentos:', error)
       toast.error('Error al cargar documentos')

--- a/app/vicerrector/layout.tsx
+++ b/app/vicerrector/layout.tsx
@@ -41,7 +41,10 @@ export default function VicerrectorLayout({
         return
       }
 
-      setUser(userData)
+      setUser({
+        ...userData,
+        nombre_completo: `${userData.apellidos ?? ''} ${userData.nombres ?? ''}`.trim(),
+      })
     } catch (error) {
       console.error('Error:', error)
       router.push('/auth/login')

--- a/app/vicerrector/page.tsx
+++ b/app/vicerrector/page.tsx
@@ -47,7 +47,10 @@ export default function VicerrectorDashboard() {
       }
 
       if (userData) {
-        setUser(userData)
+        setUser({
+          ...userData,
+          nombre_completo: `${userData.apellidos ?? ''} ${userData.nombres ?? ''}`.trim()
+        })
       }
     } catch (error) {
       console.error('Error:', error)

--- a/types/database.ts
+++ b/types/database.ts
@@ -4,7 +4,7 @@ export type UserRole = 'docente' | 'vicerrector' | 'admin'
 
 export interface Usuario {
   id: string
-  nombre_completo: string
+  nombre_completo?: string
   correo: string
   rol: UserRole
   activo: boolean


### PR DESCRIPTION
## Summary
- avoid inserting the nonexistent `nombre_completo` column when creating or updating users
- compute `nombre_completo` on the client after fetching users
- update pages that relied on the column
- make `nombre_completo` optional in TypeScript types

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b33a70878832887a72184406dc52a