### PR TITLE
fix user creation error

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -82,7 +82,6 @@ export async function POST(request: NextRequest) {
     }
 
     // Crear registro en tabla usuarios
-    const nombre_completo = `${apellidos} ${nombres}`.trim()
 
     const { error: dbError } = await supabaseAdmin
       .from('usuarios')
@@ -121,7 +120,7 @@ export async function POST(request: NextRequest) {
       user: {
         id: authData.user.id,
         email: authData.user.email,
-        nombre_completo
+        nombre_completo: `${apellidos} ${nombres}`.trim()
       }
     })
 


### PR DESCRIPTION
## Summary
- compute `nombre_completo` only for the API response

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b41d021688328a087867868fba0f9