### PR TITLE
fix user creation error

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -82,9 +82,8 @@ export async function POST(request: NextRequest) {
     }
 
     // Crear registro en tabla usuarios
-    const nombre_completo = `${apellidos} ${nombres}`.trim()
 
-    const { error: dbError } = await supabaseAdmin
+    const { data: dbUser, error: dbError } = await supabaseAdmin
       .from('usuarios')
       .insert({
         id: authData.user.id,
@@ -97,6 +96,8 @@ export async function POST(request: NextRequest) {
         rol: 'docente',
         activo: true
       })
+      .select('id')
+      .single()
 
     if (dbError) {
       console.error('Error creating user record:', dbError)
@@ -119,9 +120,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       success: true,
       user: {
-        id: authData.user.id,
+        id: dbUser?.id || authData.user.id,
         email: authData.user.email,
-        nombre_completo
+        nombre_completo: `${apellidos} ${nombres}`.trim()
       }
     })
 


### PR DESCRIPTION
## Summary
- compute `nombre_completo` only for the API response
- return inserted id after creating a user

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b41d021688328a087867868fba0f9