### PR TITLE
Manejo de error al fallar conexion con Edge Function

### DIFF
--- a/lib/auth/cliente.ts
+++ b/lib/auth/cliente.ts
@@ -29,7 +29,15 @@ export async function iniciarSesion(correo: string, password: string) {
     return { success: true, session, user }
   } catch (error: any) {
     console.error('Error inesperado en iniciarSesion:', error)
-    return { success: false, error: error.message || error }
+    const fetchFail =
+      typeof error?.message === 'string' &&
+      error.message.includes('Failed to send a request to the Edge Function')
+    return {
+      success: false,
+      error: fetchFail
+        ? 'No se pudo contactar al servidor de autenticación'
+        : error.message || error
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- improve error handling when login edge function fails

## Testing
- `npm run lint` *(fails: Next.js asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_686c4a6135f88328a4d5ace699aa5898