### PR TITLE
Mejoras al verificar configuracion de Supabase

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase/client'
 import toast from 'react-hot-toast'
@@ -14,6 +14,17 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false)
   const [needsProfile, setNeedsProfile] = useState(false)
   const [authUser, setAuthUser] = useState<any>(null)
+
+  useEffect(() => {
+    if (
+      !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+      process.env.NEXT_PUBLIC_SUPABASE_URL.includes('<') ||
+      !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY.includes('<')
+    ) {
+      toast.error('Variables de entorno de Supabase no configuradas')
+    }
+  }, [])
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/lib/auth/cliente.ts
+++ b/lib/auth/cliente.ts
@@ -1,8 +1,20 @@
 import { supabase } from '@/lib/supabase/client'
 
+function supabaseConfigValida() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+  return url.trim() !== '' && anon.trim() !== '' && !url.includes('<') && !anon.includes('<')
+}
+
 // Iniciar sesión usando Edge Function
 export async function iniciarSesion(correo: string, password: string) {
   try {
+    if (!supabaseConfigValida()) {
+      return {
+        success: false,
+        error: 'Supabase no está configurado correctamente'
+      }
+    }
     const { data, error } = await supabase.functions.invoke('login-completo', {
       body: JSON.stringify({ correo, password }),
       method: 'POST',
@@ -29,7 +41,15 @@ export async function iniciarSesion(correo: string, password: string) {
     return { success: true, session, user }
   } catch (error: any) {
     console.error('Error inesperado en iniciarSesion:', error)
-    return { success: false, error: error.message || error }
+    const fetchFail =
+      typeof error?.message === 'string' &&
+      error.message.includes('Failed to send a request to the Edge Function')
+    return {
+      success: false,
+      error: fetchFail
+        ? 'No se pudo contactar al servidor de autenticación'
+        : error.message || error
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- check Supabase env vars before calling the login edge function
- warn on login page if Supabase env vars are missing

## Testing
- `npm run lint` *(fails: Next.js asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_686c4a6135f88328a4d5ace699aa5898