### PR TITLE
Fix ambiguous types

### DIFF
--- a/app/api/documentos/upload/route.ts
+++ b/app/api/documentos/upload/route.ts
@@ -281,7 +281,10 @@ export async function POST(request: NextRequest) {
         periodo_id: periodoId ? parseInt(periodoId) : null,
         asignatura_id: asignaturaId ? parseInt(asignaturaId) : null,
         etapa_id: etapaId ? parseInt(etapaId) : null,
-        curso_asignatura_id: curso_asignatura_id !== undefined && curso_asignatura_id !== null ? parseInt(curso_asignatura_id as any) : null,
+        curso_asignatura_id:
+          curso_asignatura_id !== undefined && curso_asignatura_id !== null
+            ? parseInt(String(curso_asignatura_id))
+            : null,
         nombre_archivo: uniqueFileName,
         nombre_original: file.name,
         tamaño_bytes: buffer.length,

--- a/app/docente/page.tsx
+++ b/app/docente/page.tsx
@@ -20,11 +20,12 @@ interface CargaHorariaCompleta {
   }
 }
 
-interface EntregaPendiente {
+interface EntregaPendiente extends EntregaProgramada {
   tipo_documento: {
     nombre: string
     codigo: string
   }
+  etapa?: Etapa
   dias_restantes: number
   vencido: boolean
 }
@@ -770,8 +771,8 @@ const [stats, setStats] = useState({
                     entregasPendientes.slice(0, 5).map((entrega, idx) => {
                       // Nombre detallado: tipo documento + título/desc si aplica
                       let detalle = entrega.tipo_documento?.nombre || 'Documento';
-                      if ((entrega as any).titulo) detalle += ` - ${(entrega as any).titulo}`;
-                      else if ((entrega as any).descripcion) detalle += ` - ${(entrega as any).descripcion}`;
+                      if (entrega.titulo) detalle += ` - ${entrega.titulo}`;
+                      else if (entrega.descripcion) detalle += ` - ${entrega.descripcion}`;
                       return (
                         <li key={idx} className="flex items-center gap-2 text-sm">
                           <span className={`inline-block w-2 h-2 rounded-full ${entrega.vencido ? 'bg-red-500' : entrega.dias_restantes <= 2 ? 'bg-yellow-400' : 'bg-green-500'}`}></span>
@@ -794,8 +795,8 @@ const [stats, setStats] = useState({
                   ) : (
                     entregasPendientes.filter(e => e.vencido || e.dias_restantes <= 2).map((entrega, idx) => {
                       let detalle = entrega.tipo_documento?.nombre || 'Documento';
-                      if ((entrega as any).titulo) detalle += ` - ${(entrega as any).titulo}`;
-                      else if ((entrega as any).descripcion) detalle += ` - ${(entrega as any).descripcion}`;
+                      if (entrega.titulo) detalle += ` - ${entrega.titulo}`;
+                      else if (entrega.descripcion) detalle += ` - ${entrega.descripcion}`;
                       return (
                         <li key={idx} className="flex items-center gap-2 text-sm">
                           <span className={`inline-block w-2 h-2 rounded-full ${entrega.vencido ? 'bg-red-500' : 'bg-yellow-400'}`}></span>

--- a/app/vicerrector/importar/page.tsx
+++ b/app/vicerrector/importar/page.tsx
@@ -4,10 +4,20 @@ import toast from 'react-hot-toast';
 import { supabase } from '@/lib/supabase/client';
 import { useRouter } from 'next/navigation';
 
+interface ManualUser {
+  correo: string
+  password: string
+  apellidos: string
+  nombres: string
+  area: string
+  titulo: string
+  cedula?: string
+}
+
 export default function ImportarUsuariosPage() {
   const [csvData, setCsvData] = useState<string>('');
-  const [manualUsers, setManualUsers] = useState([
-    { correo: '', password: '', apellidos: '', nombres: '', area: '', titulo: '' }
+  const [manualUsers, setManualUsers] = useState<ManualUser[]>([
+    { correo: '', password: '', apellidos: '', nombres: '', area: '', titulo: '', cedula: '' }
   ]);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
@@ -45,12 +55,17 @@ export default function ImportarUsuariosPage() {
 
   // Handler para agregar usuario manual
   const addManualUser = () => {
-    setManualUsers([...manualUsers, { correo: '', password: '', apellidos: '', nombres: '', area: '', titulo: '' }]);
+    setManualUsers([
+      ...manualUsers,
+      { correo: '', password: '', apellidos: '', nombres: '', area: '', titulo: '', cedula: '' }
+    ]);
   };
 
   // Handler para cambiar datos manuales
-  const handleManualChange = (idx: number, field: string, value: string) => {
-    const updated = manualUsers.map((u, i) => i === idx ? { ...u, [field]: value } : u);
+  const handleManualChange = (idx: number, field: keyof ManualUser, value: string) => {
+    const updated = manualUsers.map((u, i) =>
+      i === idx ? { ...u, [field]: value } : u
+    );
     setManualUsers(updated);
   };
 
@@ -64,7 +79,7 @@ export default function ImportarUsuariosPage() {
         await supabase.rpc('crear_usuario_completo', {
           p_email: user.correo,
           p_password: user.password,
-          p_cedula: (user as any).cedula || null,
+          p_cedula: user.cedula || null,
           p_apellidos: user.apellidos,
           p_nombres: user.nombres,
           p_area: user.area || null,


### PR DESCRIPTION
## Summary
- extend `EntregaPendiente` to inherit from `EntregaProgramada`
- clean up `entrega` details without `any` casts
- define `ManualUser` type for user import flow
- update `upload` API to parse course-asignatura id without casting

## Testing
- `npx next lint` *(fails: Need to install packages)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785db9bc188328a5671e6cb3ed69b9